### PR TITLE
Canonicalize CRAN links

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -23,7 +23,7 @@ knitr::opts_chunk$set(
 [![Codecov test coverage](https://codecov.io/gh/nldoc/nlrx/branch/master/graph/badge.svg)](https://codecov.io/gh/ropensci/nlrx?branch=master)
 [![lifecycle](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://www.tidyverse.org/lifecycle/#maturing)
 [![CRAN status](https://www.r-pkg.org/badges/version/nlrx)](https://cran.r-project.org/package=nlrx)
-[![](http://cranlogs.r-pkg.org/badges/grand-total/nlrx)](http://cran.rstudio.com/web/packages/nlrx/index.html)
+[![](https://cranlogs.r-pkg.org/badges/grand-total/nlrx)](https://cran.rstudio.com/package=nlrx)
 [![ropensci](https://badges.ropensci.org/262_status.svg)](https://github.com/ropensci/onboarding/issues/262)
 
 The nlrx package provides tools to setup and execute NetLogo simulations from R.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ coverage](https://codecov.io/gh/nldoc/nlrx/branch/master/graph/badge.svg)](https
 [![lifecycle](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://www.tidyverse.org/lifecycle/#maturing)
 [![CRAN
 status](https://www.r-pkg.org/badges/version/nlrx)](https://cran.r-project.org/package=nlrx)
-[![](http://cranlogs.r-pkg.org/badges/grand-total/nlrx)](http://cran.rstudio.com/web/packages/nlrx/index.html)
+[![](https://cranlogs.r-pkg.org/badges/grand-total/nlrx)](https://cran.rstudio.com/package=nlrx)
 [![ropensci](https://badges.ropensci.org/262_status.svg)](https://github.com/ropensci/onboarding/issues/262)
 
 The nlrx package provides tools to setup and execute NetLogo simulations

--- a/docs/index.html
+++ b/docs/index.html
@@ -302,7 +302,7 @@ nl &lt;-<span class="st"> </span><span class="kw"><a href="reference/nl.html">nl
 <li><a href="https://codecov.io/gh/ropensci/nlrx?branch=master"><img src="https://codecov.io/gh/nldoc/nlrx/branch/master/graph/badge.svg" alt="Codecov test coverage"></a></li>
 <li><a href="https://www.tidyverse.org/lifecycle/#maturing"><img src="https://img.shields.io/badge/lifecycle-maturing-blue.svg" alt="lifecycle"></a></li>
 <li><a href="https://cran.r-project.org/package=nlrx"><img src="https://www.r-pkg.org/badges/version/nlrx" alt="CRAN status"></a></li>
-<li><a href="http://cran.rstudio.com/web/packages/nlrx/index.html"><img src="http://cranlogs.r-pkg.org/badges/grand-total/nlrx"></a></li>
+<li><a href="https://cran.rstudio.com/package=nlrx"><img src="https://cranlogs.r-pkg.org/badges/grand-total/nlrx"></a></li>
 <li><a href="https://github.com/ropensci/onboarding/issues/262"><img src="https://badges.ropensci.org/262_status.svg" alt="ropensci"></a></li>
 </ul>
 </div>


### PR DESCRIPTION
[CRAN asks to use the URL variant](https://cran.r-project.org/doc/manuals/R-exts.html#Specifying-URLs) when linking to packages ;-) This PR results from a semi-automatic search-and-replace script and implements their suggestion.
