### PR TITLE
Proposed bug fixes for nldoc

### DIFF
--- a/R/nldoc.R
+++ b/R/nldoc.R
@@ -59,7 +59,7 @@ nldoc <- function(modelfiles,
                   output_format = "html",
                   number_sections = TRUE,
                   theme = "journal",
-                  date = today(),
+                  date = as.Date(Sys.time()),
                   toc = TRUE)
 {
   ## Read code from provided netlogo files:

--- a/R/nldoc_parse_modelcode.R
+++ b/R/nldoc_parse_modelcode.R
@@ -72,8 +72,8 @@ nldoc_parse_modelcode <- function(nlogocode)
                             grep(pattern=";`@global", gsub(" ", "", modelcode, fixed = TRUE)) > start)[1],
                      subset(grep(pattern=";`@procedure", gsub(" ", "", modelcode, fixed = TRUE)),
                             grep(pattern=";`@procedure", gsub(" ", "", modelcode, fixed = TRUE)) > start)[1],
-                     subset(grep(pattern="TO", toupper(modelcode)),
-                            grep(pattern="TO", toupper(modelcode)) > start)[1]), na.rm = TRUE) - 1)
+                     subset(grep(pattern="^TO", toupper(modelcode)),
+                            grep(pattern="^TO", toupper(modelcode)) > start)[1]), na.rm = TRUE) - 1)
 
 
           codelines <- ""


### PR DESCRIPTION
Change default for nldoc date from lubridate to base function (caused an error when I tried to run the function).
Change grep pattern in nldoc_parse_modelcode from "TO" to "^TO" to only match "TO" that begins a new line (this caused an error where a variable that included the word "inventory" was recognized as a "TO" statement.